### PR TITLE
Add juleaften to DK

### DIFF
--- a/src/holidays-nordic.js
+++ b/src/holidays-nordic.js
@@ -25,6 +25,7 @@ const lang = {
         'General Prayer Day': 'Store bededag',
         'Ascension Day': 'Kristi Himmelfartsdag',
         'Pentecost': 'Pinsedag',
+        'Christmas Eve': 'juleaften',    
         'Christmas Day': 'Juledag',
         'Second Day of Christmas': 'Anden juledag',
         'New Year\'s Eve': 'Nytårsaften'


### PR DESCRIPTION
I've added the local name for Christmas Eve to DK translations. I'm a bit unsure if it should be added with a capital first letter or not, looking at the swedish translations I can not see a pattern - it is mixed (and not according to any rule I know of).